### PR TITLE
Do not generate confirmation_token on create

### DIFF
--- a/lib/janus/models/confirmable.rb
+++ b/lib/janus/models/confirmable.rb
@@ -17,9 +17,6 @@ module Janus
         rescue
         end
         janus_config(:confirmation_key)
-
-        before_create :generate_confirmation_token
-#        before_update :generate_confirmation_token, :if => :email_changed?
       end
 
       # Generates the confirmation token, but won't save the record.


### PR DESCRIPTION
generate_confirmation_token touches sent_at timestamp so generating a token on create makes sent_at timestamp useless. I would also remove sent_at timestamp, but you probably added it for some reason.
