### PR TITLE
Validate host before redirect on login

### DIFF
--- a/test/functional/users/sessions_controller_test.rb
+++ b/test/functional/users/sessions_controller_test.rb
@@ -48,6 +48,13 @@ class Users::SessionsControllerTest < ActionController::TestCase
     assert_authenticated(:user)
   end
 
+  test "create should skip redirect on invalid host" do
+    request.host = "invalid.test.host"
+    post :create, :user => @valid, :return_to => root_path
+    assert_redirected_to user_url
+    assert_authenticated(:user)
+  end
+
   test "create should not redirect to unknown host" do
     post :create, :user => @valid, :return_to => root_url(:host => 'www.bad-host.com')
     assert_redirected_to user_url

--- a/test/rails_app/app/controllers/users/sessions_controller.rb
+++ b/test/rails_app/app/controllers/users/sessions_controller.rb
@@ -5,6 +5,10 @@ class Users::SessionsController < Janus::SessionsController
     user_url
   end
 
+  def valid_host?(host)
+    super && host != "invalid.test.host"
+  end
+
   def valid_remote_host?(host)
     ['www.example.com', 'test.host'].include?(host)
   end


### PR DESCRIPTION
Janus used to blindly redirect to `params[:return_to]` whenever the host was request.host (no security issues), but the developer was missing the possibility to interupt the redirect if the host isn't accessible for some reason. This PR thus introduces the `valid_host?` method to allow it.
