### PR TITLE
logout when resetting password

### DIFF
--- a/lib/janus/controllers/passwords_controller.rb
+++ b/lib/janus/controllers/passwords_controller.rb
@@ -46,6 +46,7 @@ class Janus::PasswordsController < ApplicationController
 
     if resource
       if resource.reset_password!(params[resource_name])
+        janus.logout
         respond_to do |format|
           format.html { redirect_after_password_change(self.resource, :notice => t('flash.janus.passwords.update.password_updated')) }
           format.any  { head :ok }

--- a/test/functional/users/passwords_controller_test.rb
+++ b/test/functional/users/passwords_controller_test.rb
@@ -86,6 +86,21 @@ class Users::PasswordsControllerTest < ActionController::TestCase
     assert users(:julien).valid_password?(@attributes[:password])
   end
 
+  test "should logout when updating" do
+    puts 'starting test'
+
+    sign_in users(:martha)
+    users(:julien).generate_reset_password_token!
+
+    put :update, :user => @attributes.merge(
+      :reset_password_token => users(:julien).reset_password_token
+    )
+
+    puts 'end of test'
+
+    refute_equal users(:martha).id, (session['janus']['user']['user_id'] rescue nil)
+  end
+
   test "should not update" do
     users(:julien).generate_reset_password_token!
 


### PR DESCRIPTION
if a user is already logged in and try to reset the password of someone else, he will be redirected to the root_url but still logged in as the first user, which can be confusing. 
